### PR TITLE
Remove unnecessary pass statement

### DIFF
--- a/linedraw.py
+++ b/linedraw.py
@@ -178,7 +178,6 @@ def sketch(path):
         except FileNotFoundError:
             print("The Input File wasn't found. Check Path")
             exit(0)
-            pass
     w,h = IM.size
 
     IM = IM.convert("L")


### PR DESCRIPTION
## Summary
- eliminate leftover `pass` after the program exits on a missing file

## Testing
- `python -m py_compile linedraw.py filters.py perlin.py strokesort.py util.py`

------
https://chatgpt.com/codex/tasks/task_e_684a5160d4f8832b8868926b4f163b34