### PR TITLE
Use context manager when writing SVG output

### DIFF
--- a/linedraw.py
+++ b/linedraw.py
@@ -198,9 +198,8 @@ def sketch(path):
             draw.line(l,(0,0,0),5)
         disp.show()
 
-    f = open(export_path,'w')
-    f.write(makesvg(lines))
-    f.close()
+    with open(export_path, 'w') as f:
+        f.write(makesvg(lines))
     print(len(lines),"strokes.")
     print("done.")
     return lines


### PR DESCRIPTION
## Summary
- ensure `sketch()` writes SVG with a context manager

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684a515b93f4832b8357546fda8430d5