### PR TITLE
Add simple Flask web GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,19 @@ linedraw.visualize(lines)                   # simulates plotter behavior
                                             # draw the lines in order using turtle graphics.
 ```
 
+## Web Interface
+
+A simple Flask application is provided to tweak parameters through a GUI.
+
+Run the web server:
+
+```bash
+python web/app.py
+```
+
+Open your browser at `http://localhost:5000` and upload an image. The page
+lets you adjust hatch size and contour simplification with sliders and enables
+or disables hatching/contours. After processing, the intermediate grayscale and
+contrast images along with the final drawing are displayed and the generated SVG
+can be downloaded.
+

--- a/web/app.py
+++ b/web/app.py
@@ -1,0 +1,56 @@
+from flask import Flask, render_template, request, send_from_directory, redirect, url_for
+import os
+import uuid
+import linedraw
+
+app = Flask(__name__)
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+UPLOAD_FOLDER = os.path.join(BASE_DIR, 'uploads')
+OUTPUT_FOLDER = os.path.join(BASE_DIR, 'static')
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/process', methods=['POST'])
+def process():
+    img = request.files.get('image')
+    if not img:
+        return redirect(url_for('index'))
+    filename = str(uuid.uuid4()) + os.path.splitext(img.filename)[1]
+    in_path = os.path.join(UPLOAD_FOLDER, filename)
+    img.save(in_path)
+
+    hatch_size = int(request.form.get('hatch_size', 16))
+    contour_simplify = int(request.form.get('contour_simplify', 2))
+    draw_hatch = 'draw_hatch' in request.form
+    draw_contours = 'draw_contours' in request.form
+    no_cv = 'no_cv' in request.form
+
+    out_svg = os.path.join(OUTPUT_FOLDER, filename + '.svg')
+    lines, steps = linedraw.sketch_steps(
+        in_path,
+        output_path=out_svg,
+        draw_contours_opt=draw_contours,
+        draw_hatch_opt=draw_hatch,
+        hatch_size_opt=hatch_size,
+        contour_simplify_opt=contour_simplify,
+        no_cv_opt=no_cv,
+    )
+
+    step_paths = {}
+    for name, image in steps.items():
+        p = os.path.join(OUTPUT_FOLDER, filename + f'_{name}.png')
+        image.save(p)
+        step_paths[name] = os.path.basename(p)
+
+    return render_template('result.html', steps=step_paths, svg=os.path.basename(out_svg))
+
+@app.route('/static/<path:filename>')
+def static_files(filename):
+    return send_from_directory(OUTPUT_FOLDER, filename)
+
+if __name__ == '__main__':
+    os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+    os.makedirs(OUTPUT_FOLDER, exist_ok=True)
+    app.run(debug=True)

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>LineDraw Web</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 40px; }
+    label { display: block; margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <h1>LineDraw Web</h1>
+  <form action="/process" method="post" enctype="multipart/form-data">
+    <label>Image: <input type="file" name="image" required></label>
+    <label>Hatch Size: <input type="range" name="hatch_size" min="8" max="32" step="8" value="16" oninput="hatchVal.value=this.value"><output id="hatchVal">16</output></label>
+    <label>Contour Simplify: <input type="range" name="contour_simplify" min="1" max="3" step="1" value="2" oninput="contourVal.value=this.value"><output id="contourVal">2</output></label>
+    <label><input type="checkbox" name="draw_hatch" checked> Draw Hatch</label>
+    <label><input type="checkbox" name="draw_contours" checked> Draw Contours</label>
+    <label><input type="checkbox" name="no_cv"> Disable OpenCV</label>
+    <button type="submit">Process</button>
+  </form>
+</body>
+</html>

--- a/web/templates/result.html
+++ b/web/templates/result.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Result</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 40px; }
+    .images img { max-width: 200px; margin-right: 10px; }
+  </style>
+</head>
+<body>
+  <h1>Result</h1>
+  <div class="images">
+    <img src="/static/{{ steps['original'] }}" alt="original">
+    <img src="/static/{{ steps['grayscale'] }}" alt="grayscale">
+    <img src="/static/{{ steps['contrast'] }}" alt="contrast">
+    <img src="/static/{{ steps['final'] }}" alt="final">
+  </div>
+  <p><a href="/static/{{ svg }}">Download SVG</a></p>
+  <p><a href="/">Process another image</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `sketch_steps` helper returning intermediate images
- create simple Flask app with sliders to set linedraw options
- provide basic HTML pages to upload an image and show results
- document how to run the web interface

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python web/app.py --help` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684a528f9254832b8545e884ebe4f89b